### PR TITLE
Add cookie-protected /me page

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export default async function MePage() {
+  const cookieStore = await cookies();
+  const friendCookie = cookieStore.get('friendsorfamily');
+
+  if (!friendCookie) {
+    redirect('/');
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-2xl font-bold">Welcome to my page!</h1>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,6 +82,8 @@ export default function Home() {
     const userAnswer = answer.trim().toLowerCase();
     const correct = selected.answers?.some((a) => a.trim().toLowerCase() === userAnswer);
     if (correct) {
+      // Set a cookie so the /me page can verify access
+      document.cookie = `friendsorfamily=${encodeURIComponent(userAnswer)}; path=/`;
       router.push(selected.path);
     } else {
       alert("Incorrect answer, try again!");


### PR DESCRIPTION
## Summary
- set `friendsorfamily` cookie after answering favorite celebrity question
- add `/me` page that redirects to home if the cookie is missing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ee4e8de88327b113d251324c40fb