### PR TITLE
Fix Nineties Times project link and text

### DIFF
--- a/src/app/developer/page.tsx
+++ b/src/app/developer/page.tsx
@@ -23,6 +23,7 @@ interface Project {
   role: string;
   period: string;
   description: string[];
+  link?: string;
 }
 interface Experience {
   title: string;
@@ -124,18 +125,19 @@ const projects: Project[] = [
     role: "Chef de projet/Développeur",
     period: "FEV 2025 - Juillet 2025",
     description: [
-      "Site web : www.90stimes.com",
+      "Site web : https://www.90stimes.com",
       "Frontend : Next.js | Backend : ASP.NET Web API",
-      "Base de donnAces : PostgreSQL",
+      "Base de données : PostgreSQL",
       "Reverse proxy : Nginx",
-      "Cartes : OpenStreetMap (Leaflet prAvu)",
-      "MAtA�o : API met.no (locationforecast 2.0)",
-      "Personnalisation : IP pour news & mAtA�o",
+      "Cartes : OpenStreetMap (Leaflet prévu)",
+      "Météo : API met.no (Locationforecast 2.0)",
+      "Personnalisation : IP pour news & météo",
       "Contenu : articles tech, nouvelles géo, recettes de cocktails (18+), jeux en ligne, outils",
       "Authentification via Google OAuth ou inscription",
       "Fonctionnalités : likes, commentaires, Q&A",
       "Configuration en cours dans Docker",
     ],
+    link: "https://www.90stimes.com",
   },
 ];
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -8,6 +8,7 @@ interface Project {
   role: string;
   period: string;
   description: string[];
+  link?: string;
 }
 
 interface ProjectsSectionProps {
@@ -102,7 +103,7 @@ const ProjectsSection: React.FC<ProjectsSectionProps> = ({ projects, hueRotation
           }}
         >
           {projects.map((project, index) => {
-            const projectLink = getProjectLink(project.title);
+            const projectLink = project.link ?? getProjectLink(project.title);
             return (
               <MotionDiv
                 key={index}


### PR DESCRIPTION
## Summary
- allow projects to provide explicit links when rendering the developer projects carousel
- correct the 90stimes.com project entry with a proper URL and readable French accents

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4298d39908327a3c97d526c7bb0bc