### PR TITLE
Add explicit project links for developer portfolio

### DIFF
--- a/src/app/developer/page.tsx
+++ b/src/app/developer/page.tsx
@@ -23,6 +23,7 @@ interface Project {
   role: string;
   period: string;
   description: string[];
+  link?: string;
 }
 interface Experience {
   title: string;
@@ -72,6 +73,7 @@ const projects: Project[] = [
     title: "NAVXPERT: APPLICATION WEB DE NAVIGATION",
     role: "Développeur",
     period: "SEPTEMBRE 2024 - FÉVRIER 2025",
+    link: "https://navxpert.anamolkarki.com",
     description: [
       "Site web : navxpert.anamolkarki.com",
       "Solution numérique pour web et mobile",
@@ -89,6 +91,7 @@ const projects: Project[] = [
     title: "ECONOMITIENS: SUIVI DE LA CONSOMMATION ÉLECTRIQUE",
     role: "Développeur",
     period: "MARS 2024 - JUILLET 2024",
+    link: "https://github.com/ajk-5/E-CONOMITIENS",
     description: [
       "Application desktop",
       "Technologies : C#, WPF (MVVM), XAML, MySQL, Arduino, UML",
@@ -101,6 +104,7 @@ const projects: Project[] = [
     title: "ESIEACCASION : SECOND-HAND MARKETPLACE",
     role: "Chef de projet/Développeur",
     period: "SEPTEMBRE 2023 - FÉVRIER 2024",
+    link: "https://github.com/ajk-5/Accassion",
     description: [
       "Plateforme en ligne pour articles d'occasion",
       "Technologies : PHP, MySQL, HTML/CSS, modèle MVC",
@@ -112,6 +116,7 @@ const projects: Project[] = [
     title: "ASTAVOID : JEUX DES MINES",
     role: "Chef de projet/Développeur",
     period: "MARS 2023 - JUILLET 2023",
+    link: "https://astavoid.anamolkarki.com",
     description: [
       "Jeu interactif sur le web",
       "Technologies : JavaScript, Node.js, HTML, CSS, Nunjucks",
@@ -123,6 +128,7 @@ const projects: Project[] = [
     title: "90stimes.com: The Nineties Times",
     role: "Chef de projet/Développeur",
     period: "FEV 2025 - Juillet 2025",
+    link: "https://90stimes.com",
     description: [
       "Site web : www.90stimes.com",
       "Frontend : Next.js | Backend : ASP.NET Web API",

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -8,6 +8,7 @@ interface Project {
   role: string;
   period: string;
   description: string[];
+  link?: string;
 }
 
 interface ProjectsSectionProps {
@@ -102,7 +103,7 @@ const ProjectsSection: React.FC<ProjectsSectionProps> = ({ projects, hueRotation
           }}
         >
           {projects.map((project, index) => {
-            const projectLink = getProjectLink(project.title);
+            const projectLink = project.link ?? getProjectLink(project.title);
             return (
               <MotionDiv
                 key={index}


### PR DESCRIPTION
## Summary
- add an optional `link` field to the developer projects data and populate it for each entry
- have the ProjectsSection component respect a provided project link before falling back to inferred URLs, ensuring 90stimes.com is clickable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4349858b48327886ca95deb73fedb